### PR TITLE
Bluetooth: Mesh: Add sensor value utils

### DIFF
--- a/include/bluetooth/mesh/sensor.h
+++ b/include/bluetooth/mesh/sensor.h
@@ -34,7 +34,7 @@ extern "C" {
 #define BT_MESH_SENSOR_INTERVAL_MAX 26
 
 /** String length for representing a single sensor channel. */
-#define BT_MESH_SENSOR_CH_STR_LEN 19
+#define BT_MESH_SENSOR_CH_STR_LEN 23
 
 /** Sensor sampling type.
  *
@@ -120,6 +120,29 @@ struct bt_mesh_sensor;
 struct bt_mesh_sensor_srv;
 
 #if !defined(CONFIG_BT_MESH_SENSOR_USE_SENSOR_VALUE) || defined(__DOXYGEN__)
+
+/** Status of conversion from @ref bt_mesh_sensor_value. */
+enum bt_mesh_sensor_value_status {
+	/** The encoded sensor value represents a number. */
+	BT_MESH_SENSOR_VALUE_NUMBER=0,
+	/** An error ocurred during conversion from the encoded sensor value. */
+	BT_MESH_SENSOR_VALUE_CONVERSION_ERROR,
+	/** The encoded sensor value represents an unknown value. */
+	BT_MESH_SENSOR_VALUE_UNKNOWN,
+	/** The encoded sensor value represents an invalid value. */
+	BT_MESH_SENSOR_VALUE_INVALID,
+	/** The encoded sensor value represents a value greater than or equal to
+	 *  the format maximum.
+	 */
+	BT_MESH_SENSOR_VALUE_MAX_OR_GREATER,
+	/** The encoded sensor value represents a value less than or equal to
+	 *  the format minimum.
+	 */
+	BT_MESH_SENSOR_VALUE_MIN_OR_LESS,
+	/** The encoded sensor value represents the total lifetime of the device. */
+	BT_MESH_SENSOR_VALUE_TOTAL_DEVICE_LIFE,
+};
+
 /** Sensor value type representing the value and format of a single channel of
  *  sensor data.
  */
@@ -194,47 +217,7 @@ struct bt_mesh_sensor_threshold {
 };
 
 /** Sensor channel value format. */
-struct bt_mesh_sensor_format {
-	/** @brief Perform a delta check between two @ref bt_mesh_sensor_value
-	 *         instances.
-	 *
-	 *  @c current and @c previous must have the same format.
-	 *
-	 *  @param[in] current  The current value.
-	 *  @param[in] previous The previous sensor value to compare against.
-	 *  @param[in] delta    The delta to use when checking.
-	 *
-	 *  @return @c true if the difference between @c current and @c previous
-	 *          is bigger than the relevant delta specified in @c delta, @c
-	 *          false otherwise.
-	 */
-	bool (*const delta_check)(const struct bt_mesh_sensor_value *current,
-				  const struct bt_mesh_sensor_value *previous,
-				  const struct bt_mesh_sensor_deltas *delta);
-
-	/** @brief Compare two @ref bt_mesh_sensor_value instances.
-	 *
-	 *  @c op1 and @c op1 must have the same format.
-	 *
-	 *  @param[in] op1 The first value to compare.
-	 *  @param[in] op2 The second value to compare.
-	 *
-	 *  @return 0 if @c op1 == @c op2, 1 if @c op1 > @c op2, -1 otherwise
-	 *          (including if @c op1 and @c op2 are not comparable).
-	 */
-	int (*const compare)(const struct bt_mesh_sensor_value *op1,
-			     const struct bt_mesh_sensor_value *op2);
-
-	/** User data pointer. Used internally by the sensor types. */
-	void *user_data;
-	/** Size of the encoded data in bytes. */
-	size_t size;
-
-#ifdef CONFIG_BT_MESH_SENSOR_LABELS
-	/** Pointer to the unit associated with this format. */
-	const struct bt_mesh_sensor_unit *unit;
-#endif
-};
+struct bt_mesh_sensor_format;
 
 /** Single sensor setting. */
 struct bt_mesh_sensor_setting {
@@ -421,22 +404,134 @@ struct bt_mesh_sensor {
 	} state;
 };
 
-/** @brief Get a human readable representation of a single sensor channel.
+/** @brief Compare two @ref bt_mesh_sensor_value instances.
  *
- *  @param[in]  ch  Sensor channel to represent.
- *  @param[out] str String buffer to fill. Should be @ref
- *                  BT_MESH_SENSOR_CH_STR_LEN bytes long.
- *  @param[in]  len Length of @c str buffer.
+ *  @param[in] a The first value to compare.
+ *  @param[in] b The second value to compare.
  *
- *  @return Number of bytes that should have been written if @c str is
- *          sufficiently large.
+ *  @return 0 if @c a == @c b, 1 if @c a > @c b, -1 otherwise (including if
+ *          @c a and @c b are not comparable).
  */
-static inline int bt_mesh_sensor_ch_to_str(const struct bt_mesh_sensor_value *ch,
-					   char *str, size_t len)
+int bt_mesh_sensor_value_compare(const struct bt_mesh_sensor_value *a,
+				 const struct bt_mesh_sensor_value *b);
+
+/** @brief Returns true if @c status is a value which can be represented by a
+ *         number, meaning one of @c BT_MESH_SENSOR_VALUE_NUMBER,
+ *         @c BT_MESH_SENSOR_VALUE_MIN_OR_LESS and
+ *         @c BT_MESH_SENSOR_VALUE_MAX_OR_GREATER.
+ *
+ *  @param[in] status The value to check.
+ *
+ *  @return @c true if @c status is numeric, @c false otherwise.
+ */
+static inline bool
+bt_mesh_sensor_value_status_is_numeric(enum bt_mesh_sensor_value_status status)
 {
-	/* TODO: Update this once util functions are available */
-	return snprintk(str, len, "(unknown format)");
+	return (status == BT_MESH_SENSOR_VALUE_NUMBER ||
+		status == BT_MESH_SENSOR_VALUE_MIN_OR_LESS ||
+		status == BT_MESH_SENSOR_VALUE_MAX_OR_GREATER);
 }
+
+/** @brief Convert a @ref bt_mesh_sensor_value to a @c float.
+ *
+ *  If this function returns a status for which
+ *  @ref bt_mesh_sensor_value_status_is_numeric returns false, @c val is not
+ *  modified.
+ *
+ *  @param[in]  sensor_val The @ref bt_mesh_sensor_value to convert.
+ *  @param[out] val        The resulting @c float.
+ *
+ *  @return The status of the conversion.
+ */
+enum bt_mesh_sensor_value_status
+bt_mesh_sensor_value_to_float(const struct bt_mesh_sensor_value *sensor_val,
+			      float *val);
+
+/** @brief Convert a @c float to a @ref bt_mesh_sensor_value.
+ *
+ *  If @c val has a value that cannot be represented by the format,
+ *  @c sensor_val will be set to the value clamped to the range supported by
+ *  the format, and this function will return -ERANGE. This will clamp to
+ *  "Greater than or equal to the maximum value" and "Less than or equal to the
+ *  minimum value" if these are supported by the format.
+ *
+ *  If this function returns an error code other than -ERANGE, @c sensor_val is
+ *  not modified.
+ *
+ *  @param[in]  format     Format to use when encoding the sensor value.
+ *  @param[in]  val        The @c float to convert.
+ *  @param[out] sensor_val The resulting @ref bt_mesh_sensor_value.
+ *
+ *  @return 0 on success, (negative) error code otherwise.
+ */
+int bt_mesh_sensor_value_from_float(const struct bt_mesh_sensor_format *format,
+				    float val,
+				    struct bt_mesh_sensor_value *sensor_val);
+
+/** @brief Convert a @ref bt_mesh_sensor_value instance to a
+ *         @ref sensor_value.
+ *
+ *  If this function returns a status for which
+ *  @ref bt_mesh_sensor_value_status_is_numeric returns false, @c val is not
+ *  modified.
+ *
+ *  @param[in]  sensor_val The @ref bt_mesh_sensor_value to convert.
+ *  @param[out] val        The resulting @ref sensor_value.
+ *
+ *  @return The status of the conversion.
+ */
+enum bt_mesh_sensor_value_status
+bt_mesh_sensor_value_to_sensor_value(
+	const struct bt_mesh_sensor_value *sensor_val,
+	struct sensor_value *val);
+
+/** @brief Convert a @ref sensor_value instance to a @ref bt_mesh_sensor_value.
+ *
+ *  If @c val has a value that cannot be represented by the format,
+ *  @c sensor_val will be set to the value clamped to the range supported by
+ *  the format, and this function will return -ERANGE. This will clamp to
+ *  "Greater than or equal to the maximum value" and "Less than or equal to the
+ *  minimum value" if these are supported by the format.
+ *
+ *  If this function returns an error code other than -ERANGE, @c sensor_val is
+ *  not modified.
+ *
+ *  @param[in]  format     Format to use when encoding the sensor value.
+ *  @param[in]  val        The @ref sensor_value to convert.
+ *  @param[out] sensor_val The resulting @ref bt_mesh_sensor_value.
+ *
+ *  @return 0 on success, (negative) error code otherwise.
+ */
+int bt_mesh_sensor_value_from_sensor_value(
+	const struct bt_mesh_sensor_format *format,
+	const struct sensor_value *val,
+	struct bt_mesh_sensor_value *sensor_val);
+
+/** @brief Return a @ref bt_mesh_sensor_value_status describing the value in a
+ *         @ref bt_mesh_sensor_value.
+ *
+ *  @param[in] sensor_val The value to return the status for.
+ *
+ *  @return The status describing the value.
+ */
+enum bt_mesh_sensor_value_status
+bt_mesh_sensor_value_get_status(const struct bt_mesh_sensor_value *sensor_val);
+
+/** @brief Convert a @ref bt_mesh_sensor_value_status value to a
+ *         @ref bt_mesh_sensor_value.
+ *
+ *  @param[in]  format     Format to use when encoding the sensor value.
+ *  @param[in]  val        The @ref bt_mesh_sensor_value_special value to
+ *                         convert.
+ *  @param[out] sensor_val The resulting @ref bt_mesh_sensor_value on success.
+ *                         Unchanged otherwise.
+ *
+ *  @return 0 on success, (negative) error code otherwise.
+ */
+int bt_mesh_sensor_value_from_special(
+	const struct bt_mesh_sensor_format *format,
+	enum bt_mesh_sensor_value_status val,
+	struct bt_mesh_sensor_value *sensor_val);
 
 /** @brief Get a human readable representation of a single sensor channel.
  *

--- a/subsys/bluetooth/mesh/sensor.c
+++ b/subsys/bluetooth/mesh/sensor.c
@@ -51,12 +51,12 @@ sensor_cadence(const struct bt_mesh_sensor_threshold *threshold,
 	const struct bt_mesh_sensor_value *high, *low;
 	const struct bt_mesh_sensor_format *fmt = curr->format;
 
-	if (fmt->compare(&threshold->range.high,
-			 &threshold->range.low) >= 0) {
+	if (fmt->cb->compare(&threshold->range.high,
+			     &threshold->range.low) >= 0) {
 		low = &threshold->range.low;
 		high = &threshold->range.high;
-	} else if (fmt->compare(&threshold->range.low,
-				&threshold->range.high) >= 0) {
+	} else if (fmt->cb->compare(&threshold->range.low,
+				    &threshold->range.high) >= 0) {
 		low = &threshold->range.high;
 		high = &threshold->range.low;
 	} else {
@@ -118,8 +118,8 @@ bool bt_mesh_sensor_delta_threshold(const struct bt_mesh_sensor *sensor,
 bool bt_mesh_sensor_delta_threshold(const struct bt_mesh_sensor *sensor,
 				    const struct bt_mesh_sensor_value *curr)
 {
-	return curr->format->delta_check(curr, &sensor->state.prev,
-					 &sensor->state.threshold.deltas);
+	return curr->format->cb->delta_check(curr, &sensor->state.prev,
+					     &sensor->state.threshold.deltas);
 }
 #endif /* defined(CONFIG_BT_MESH_SENSOR_USE_SENSOR_VALUE) */
 
@@ -688,8 +688,8 @@ int sensor_cadence_decode(struct net_buf_simple *buf,
 		threshold->range.high = threshold->range.low;
 		threshold->range.low = temp;
 #else
-	if (threshold->range.high.format->compare(&threshold->range.low,
-						  &threshold->range.high) > 0) {
+	if (threshold->range.high.format->cb->compare(&threshold->range.low,
+						      &threshold->range.high) > 0) {
 		uint8_t temp[CONFIG_BT_MESH_SENSOR_CHANNEL_ENCODED_SIZE_MAX];
 
 		memcpy(temp, &threshold->range.high.raw,
@@ -756,9 +756,6 @@ void sensor_cadence_update(struct bt_mesh_sensor *sensor,
 
 #ifdef CONFIG_BT_MESH_SENSOR_USE_SENSOR_VALUE
 const char *bt_mesh_sensor_ch_str(const struct sensor_value *ch)
-#else
-const char *bt_mesh_sensor_ch_str(const struct bt_mesh_sensor_value *ch)
-#endif
 {
 	static char str[BT_MESH_SENSOR_CH_STR_LEN];
 
@@ -768,3 +765,121 @@ const char *bt_mesh_sensor_ch_str(const struct bt_mesh_sensor_value *ch)
 
 	return str;
 }
+#else
+const char *bt_mesh_sensor_ch_str(const struct bt_mesh_sensor_value *ch)
+{
+	static char str[BT_MESH_SENSOR_CH_STR_LEN];
+	enum bt_mesh_sensor_value_status status;
+	float float_val;
+
+	if (ch->format->cb->to_string) {
+		int err;
+
+		err = ch->format->cb->to_string(ch, str, BT_MESH_SENSOR_CH_STR_LEN);
+		if (err) {
+			strcpy(str, "<unprintable value>");
+		}
+		return str;
+	}
+
+	status = ch->format->cb->to_float(ch, &float_val);
+
+	switch (status) {
+	case BT_MESH_SENSOR_VALUE_NUMBER:
+		(void)snprintk(str, BT_MESH_SENSOR_CH_STR_LEN, "%g", float_val);
+		break;
+	case BT_MESH_SENSOR_VALUE_MAX_OR_GREATER:
+		(void)snprintk(str, BT_MESH_SENSOR_CH_STR_LEN, ">=%g",
+			       float_val);
+		break;
+	case BT_MESH_SENSOR_VALUE_MIN_OR_LESS:
+		(void)snprintk(str, BT_MESH_SENSOR_CH_STR_LEN, "<=%g",
+			       float_val);
+	case BT_MESH_SENSOR_VALUE_UNKNOWN:
+		strcpy(str, "<value is not known>");
+		break;
+	case BT_MESH_SENSOR_VALUE_INVALID:
+		strcpy(str, "<value is invalid>");
+		break;
+	case BT_MESH_SENSOR_VALUE_TOTAL_DEVICE_LIFE:
+		strcpy(str, "<total life of device>");
+		break;
+	default:
+		strcpy(str, "<unprintable value>");
+	}
+
+	return str;
+}
+
+int bt_mesh_sensor_value_compare(const struct bt_mesh_sensor_value *a,
+				 const struct bt_mesh_sensor_value *b)
+{
+	if (a->format == b->format) {
+		return a->format->cb->compare(a, b);
+	}
+
+	/* Fall back to comparing floats. */
+	float a_float, b_float;
+	enum bt_mesh_sensor_value_status status;
+
+	status = bt_mesh_sensor_value_to_float(a, &a_float);
+	if (!bt_mesh_sensor_value_status_is_numeric(status)) {
+		return 0;
+	}
+
+	status = bt_mesh_sensor_value_to_float(b, &b_float);
+	if (!bt_mesh_sensor_value_status_is_numeric(status)) {
+		return 0;
+	}
+
+	return a_float > b_float ? 1 : (a_float < b_float ? -1 : 0);
+}
+
+enum bt_mesh_sensor_value_status
+bt_mesh_sensor_value_to_float(const struct bt_mesh_sensor_value *sensor_val,
+			      float *val)
+{
+	return sensor_val->format->cb->to_float(sensor_val, val);
+}
+
+int bt_mesh_sensor_value_from_float(const struct bt_mesh_sensor_format *format,
+				    float val,
+				    struct bt_mesh_sensor_value *sensor_val)
+{
+	return format->cb->from_float(format, val, sensor_val);
+}
+
+enum bt_mesh_sensor_value_status
+bt_mesh_sensor_value_to_sensor_value(
+	const struct bt_mesh_sensor_value *sensor_val,
+	struct sensor_value *val)
+{
+	return sensor_val->format->cb->to_sensor_value(sensor_val, val);
+}
+
+int bt_mesh_sensor_value_from_sensor_value(
+	const struct bt_mesh_sensor_format *format,
+	const struct sensor_value *val,
+	struct bt_mesh_sensor_value *sensor_val)
+{
+	return format->cb->from_sensor_value(format, val, sensor_val);
+}
+
+enum bt_mesh_sensor_value_status
+bt_mesh_sensor_value_get_status(const struct bt_mesh_sensor_value *sensor_val)
+{
+	return sensor_val->format->cb->to_float(sensor_val, NULL);
+}
+
+int bt_mesh_sensor_value_from_special(
+	const struct bt_mesh_sensor_format *format,
+	enum bt_mesh_sensor_value_status val,
+	struct bt_mesh_sensor_value *sensor_val)
+{
+	if (val == BT_MESH_SENSOR_VALUE_NUMBER ||
+	    val == BT_MESH_SENSOR_VALUE_CONVERSION_ERROR) {
+		return -EINVAL;
+	}
+	return format->cb->from_special(format, val, sensor_val);
+}
+#endif /* defined(CONFIG_BT_MESH_USE_SENSOR_VALUE) */

--- a/subsys/bluetooth/mesh/sensor.h
+++ b/subsys/bluetooth/mesh/sensor.h
@@ -151,8 +151,157 @@ typedef struct bt_mesh_sensor_value sensor_value_type;
 		  (_value)->val2 <= (_end)->val2)))
 #else
 #define SENSOR_VALUE_IN_RANGE(_value, _start, _end) (                          \
-		(_value)->format->compare((_value), (_start)) >= 0 &&          \
-		(_value)->format->compare((_end), (_value)) >= 0)
+		(_value)->format->cb->compare((_value), (_start)) >= 0 &&      \
+		(_value)->format->cb->compare((_end), (_value)) >= 0)
+
+struct bt_mesh_sensor_format_cb {
+	/** @brief Perform a delta check between two @ref bt_mesh_sensor_value
+	 *         instances.
+	 *
+	 *  @c current and @c previous must have the same format.
+	 *
+	 *  @param[in] current  The current value.
+	 *  @param[in] previous The previous sensor value to compare against.
+	 *  @param[in] delta    The delta to use when checking.
+	 *
+	 *  @return @c true if the difference between @c current and @c previous
+	 *          is bigger than the relevant delta specified in @c delta, @c
+	 *          false otherwise.
+	 */
+	bool (*const delta_check)(const struct bt_mesh_sensor_value *current,
+				  const struct bt_mesh_sensor_value *previous,
+				  const struct bt_mesh_sensor_deltas *delta);
+
+	/** @brief Compare two @ref bt_mesh_sensor_value instances.
+	 *
+	 *  @c op1 and @c op1 must have the same format.
+	 *
+	 *  @param[in] op1 The first value to compare.
+	 *  @param[in] op2 The second value to compare.
+	 *
+	 *  @return 0 if @c op1 == @c op2, 1 if @c op1 > @c op2, -1 otherwise
+	 *          (including if @c op1 and @c op2 are not comparable).
+	 */
+	int (*const compare)(const struct bt_mesh_sensor_value *op1,
+			     const struct bt_mesh_sensor_value *op2);
+
+	/** @brief Convert a @ref bt_mesh_sensor_value instance to a
+	 *         @ref sensor_value.
+	 *
+	 *  If this function returns a status other than
+	 *  @c BT_MESH_SENSOR_VALUE_NUMBER, @c val is not modified.
+	 *
+	 *  @param[in]  sensor_val The @ref bt_mesh_sensor_value to convert.
+	 *  @param[out] val        The resulting @ref sensor_value.
+	 *
+	 *  @return The status of the conversion.
+	 */
+	enum bt_mesh_sensor_value_status (*const to_sensor_value)(
+		const struct bt_mesh_sensor_value *sensor_val,
+		struct sensor_value *val);
+
+	/** @brief Convert a @ref sensor_value instance to a
+	 *         @ref bt_mesh_sensor_value.
+	 *
+	 *  If @c val has a value that cannot be represented by the format,
+	 *  @c sensor_val will be set to the value clamped to the range
+	 *  supported by the format, and this function will return -ERANGE.
+	 *  This will clamp to "Greater than the maximum value" and
+	 *  "Less than the minimum value" if these are supported by the format.
+	 *
+	 *  If this function returns an error code other than -ERANGE,
+	 *  @c sensor_val is not modified.
+	 *
+	 *  @param[in]  format     Format to use when encoding the sensor value.
+	 *  @param[in]  val        The @ref sensor_value to convert.
+	 *  @param[out] sensor_val The resulting @ref bt_mesh_sensor_value.
+	 *
+	 *  @return 0 on success, (negative) error code otherwise.
+	 */
+	int (*const from_sensor_value)(
+		const struct bt_mesh_sensor_format *format,
+		const struct sensor_value *val,
+		struct bt_mesh_sensor_value *sensor_val);
+
+	/** @brief Convert a @ref bt_mesh_sensor_value to a @c float.
+	 *
+	 *  If this function returns a status for which
+	 *  @ref bt_mesh_sensor_value_status_is_numeric returns false, @c val
+	 *  is not modified.
+	 *
+	 *  @param[in]  sensor_val The @ref bt_mesh_sensor_value to convert.
+	 *  @param[out] val        The resulting @c float.
+	 *
+	 *  @return The status of the conversion.
+	 */
+	enum bt_mesh_sensor_value_status (*const to_float)(
+		const struct bt_mesh_sensor_value *sensor_val, float *val);
+
+	/** @brief Convert a @c float to a @ref bt_mesh_sensor_value.
+	 *
+	 *  If @c val has a value that cannot be represented by the format,
+	 *  @c sensor_val will be set to the value clamped to the range
+	 *  supported by the format, and this function will return -ERANGE.
+	 *  This will clamp to "Greater than the maximum value" and
+	 *  "Less than the minimum value" if these are supported by the format.
+	 *
+	 *  If this function returns an error code other than -ERANGE,
+	 *  @c sensor_val is not modified.
+	 *
+	 *  @param[in]  format     Format to use when encoding the sensor value.
+	 *  @param[in]  val        The @c float to convert.
+	 *  @param[out] sensor_val The resulting @ref bt_mesh_sensor_value.
+	 *
+	 *  @return 0 on success, (negative) error code otherwise.
+	 */
+	int (*const from_float)(const struct bt_mesh_sensor_format *format,
+				float val,
+				struct bt_mesh_sensor_value *sensor_val);
+
+	/** @brief Convert a @ref bt_mesh_sensor_value_status value to a
+	 *         @ref bt_mesh_sensor_value.
+	 *
+	 *  @param[in]  format     Format to use when encoding the sensor value.
+	 *  @param[in]  val        The @ref bt_mesh_sensor_value_special value
+	 *                         to convert.
+	 *  @param[out] sensor_val The resulting @ref bt_mesh_sensor_value on
+	 *                         success. Undefined otherwise.
+	 *
+	 *  @return 0 on success, (negative) error code otherwise.
+	 */
+	int (*const from_special)(const struct bt_mesh_sensor_format *format,
+				  enum bt_mesh_sensor_value_status val,
+				  struct bt_mesh_sensor_value *sensor_val);
+
+	/** @brief Get a human readable representation of a
+	 *         @ref bt_mesh_sensor_value.
+	 *
+	 *  @param[in]  sensor_val Sensor value to represent.
+	 *  @param[out] str        String buffer to fill. Should be
+	 *                         @ref BT_MESH_SENSOR_CH_STR_LEN bytes long.
+	 *  @param[in]  len        Length of @c str buffer.
+	 *
+	 *  @return 0 if string successfully written, (negative) error code
+	 *          otherwise.
+	 */
+	int (*const to_string)(const struct bt_mesh_sensor_value *sensor_val,
+			       char *str, size_t len);
+};
+
+/** Sensor channel value format. */
+struct bt_mesh_sensor_format {
+	/** Callbacks used for this format. */
+	struct bt_mesh_sensor_format_cb *cb;
+	/** User data pointer. Used internally by the sensor types. */
+	void *user_data;
+	/** Size of the encoded data in bytes. */
+	size_t size;
+
+#ifdef CONFIG_BT_MESH_SENSOR_LABELS
+	/** Pointer to the unit associated with this format. */
+	const struct bt_mesh_sensor_unit *unit;
+#endif
+};
 
 /** @brief Check if a value change breaks the delta threshold.
  *

--- a/subsys/bluetooth/mesh/sensor_cli.c
+++ b/subsys/bluetooth/mesh/sensor_cli.c
@@ -243,7 +243,7 @@ yield_ack:
 			(rsp->col->start.val1 != entry.column.start.val1 ||
 			 rsp->col->start.val2 != entry.column.start.val2)) {
 #else
-			col_format->compare(rsp->col_start, &entry.column.start) != 0) {
+			col_format->cb->compare(rsp->col_start, &entry.column.start) != 0) {
 #endif
 			return 0;
 		}

--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -230,7 +230,7 @@ column_get(const struct bt_mesh_sensor_series *series,
 		if (series->columns[i].start.val1 == val->val1 &&
 		    series->columns[i].start.val2 == val->val2) {
 #else
-		if (val->format->compare(&series->columns[i].start, val) == 0) {
+		if (val->format->cb->compare(&series->columns[i].start, val) == 0) {
 #endif
 			return &series->columns[i];
 		}

--- a/subsys/bluetooth/mesh/sensor_types.c
+++ b/subsys/bluetooth/mesh/sensor_types.c
@@ -12,6 +12,11 @@
 #include <bluetooth/mesh/properties.h>
 #include <bluetooth/mesh/sensor_types.h>
 
+/* Constants: */
+
+/* logf(1.1f) */
+#define LOG_1_1 (0.095310203f)
+
 /* Various shorthand macros to improve readability and maintainability of this
  * file:
  */
@@ -101,7 +106,7 @@ UNIT(unitless) = { "Unitless" };
 #ifdef CONFIG_BT_MESH_SENSOR_USE_SENSOR_VALUE
 #define SCALAR_CALLBACKS .encode = scalar_encode, .decode = scalar_decode
 #else
-#define SCALAR_CALLBACKS .compare = scalar_compare, .delta_check = scalar_delta_check
+#define SCALAR_CALLBACKS .cb = &scalar_cb
 #endif
 
 #ifdef CONFIG_BT_MESH_SENSOR_LABELS
@@ -163,22 +168,34 @@ UNIT(unitless) = { "Unitless" };
 	}
 #endif
 
+#define MUL_SCALAR(_val, _repr) (((repr)->flags & DIVIDE) ?                    \
+				 ((_val) / (_repr)->value) :                   \
+				 ((_val) * (_repr)->value))
+
+#define DIV_SCALAR(_val, _repr) (((repr)->flags & DIVIDE) ?                    \
+				 ((_val) * (_repr)->value) :                   \
+				 ((_val) / (_repr)->value))
+
 enum scalar_repr_flags {
 	UNSIGNED = 0,
 	SIGNED = BIT(1),
 	DIVIDE = BIT(2),
-	/** The highest encoded value represents "undefined" */
+	/** The type maximum represents "value is not known" */
 	HAS_UNDEFINED = BIT(3),
-	/**
-	 * The highest encoded value represents
-	 * the maximum value or higher.
-	 */
+	/** The maximum value represents the maximum value or higher. */
 	HAS_HIGHER_THAN = (BIT(4)),
-	/** The second highest encoded value represents "value is invalid" */
+	/** The highest encoded value which doesn't represent "value is not
+	 *  known" represents "value is invalid".
+	 */
 	HAS_INVALID = (BIT(5)),
 	HAS_MAX = BIT(6),
 	HAS_MIN = BIT(7),
+	/** The type minimum represents "value is not known" */
 	HAS_UNDEFINED_MIN = BIT(8),
+	/** The type maximum minus 1 represents "value is not known" */
+	HAS_UNDEFINED_MAX_MINUS_1 = BIT(9),
+	/** The minimum value represents the minimum value or lower. */
+	HAS_LOWER_THAN = BIT(10),
 };
 
 struct scalar_repr {
@@ -187,6 +204,56 @@ struct scalar_repr {
 	uint32_t max; /**< Highest encoded value */
 	int64_t value;
 };
+
+static uint32_t scalar_type_max(const struct bt_mesh_sensor_format *format)
+{
+	const struct scalar_repr *repr = format->user_data;
+
+	return (repr->flags & SIGNED) ?
+		BIT64(8 * format->size - 1) - 1 :
+		BIT64(8 * format->size) - 1;
+}
+
+static int32_t scalar_type_min(const struct bt_mesh_sensor_format *format)
+{
+	const struct scalar_repr *repr = format->user_data;
+
+	return (repr->flags & SIGNED) ? -BIT64(8 * format->size - 1) : 0;
+}
+
+static int64_t scalar_max(const struct bt_mesh_sensor_format *format)
+{
+	const struct scalar_repr *repr = format->user_data;
+
+	if (repr->flags & HAS_MAX) {
+		return repr->max;
+	}
+
+	uint32_t max_value = scalar_type_max(format);
+
+	if (repr->flags & HAS_INVALID) {
+		max_value -= 2;
+	} else if (repr->flags & HAS_UNDEFINED) {
+		max_value -= 1;
+	}
+
+	return max_value;
+}
+
+static int32_t scalar_min(const struct bt_mesh_sensor_format *format)
+{
+	const struct scalar_repr *repr = format->user_data;
+
+	if (repr->flags & HAS_MIN) {
+		return repr->min;
+	}
+
+	if (repr->flags & HAS_UNDEFINED_MIN) {
+		return scalar_type_min(format) + 1;
+	}
+
+	return scalar_type_min(format);
+}
 
 static int scalar_decode_raw(const struct bt_mesh_sensor_format *format,
 			     const uint8_t *src, int64_t *raw)
@@ -225,60 +292,30 @@ static int scalar_decode_raw(const struct bt_mesh_sensor_format *format,
 	return 0;
 }
 
-#ifdef CONFIG_BT_MESH_SENSOR_USE_SENSOR_VALUE
-static int64_t mul_scalar(int64_t val, const struct scalar_repr *repr)
+static int scalar_encode_raw(const struct bt_mesh_sensor_format *format,
+			     int64_t raw, uint8_t *dst)
 {
-	return (repr->flags & DIVIDE) ? (val / repr->value) :
-	       (val * repr->value);
-}
-
-static int64_t div_scalar(int64_t val, const struct scalar_repr *repr)
-{
-	return (repr->flags & DIVIDE) ? (val * repr->value) :
-	       (val / repr->value);
-}
-
-static int64_t scalar_max(const struct bt_mesh_sensor_format *format)
-{
-	const struct scalar_repr *repr = format->user_data;
-
-	if (repr->flags & HAS_MAX) {
-		return repr->max;
-	}
-
-	int64_t max_value = BIT64(8 * format->size) - 1;
-
-	if (repr->flags & SIGNED) {
-		max_value = BIT64(8 * format->size - 1) - 1;
-	}
-
-	if (repr->flags & HAS_INVALID) {
-		max_value -= 2;
-	} else if (repr->flags & HAS_UNDEFINED) {
-		max_value -= 1;
-	}
-
-	return max_value;
-}
-
-static int32_t scalar_min(const struct bt_mesh_sensor_format *format)
-{
-	const struct scalar_repr *repr = format->user_data;
-
-	if (repr->flags & HAS_MIN) {
-		return repr->min;
-	}
-
-	if (repr->flags & SIGNED) {
-		if (repr->flags & HAS_UNDEFINED_MIN) {
-			return -BIT64(8 * format->size - 1) + 1;
-		}
-		return -BIT64(8 * format->size - 1);
+	switch (format->size) {
+	case 1:
+		*dst = raw;
+		break;
+	case 2:
+		sys_put_le16(raw, dst);
+		break;
+	case 3:
+		sys_put_le24(raw, dst);
+		break;
+	case 4:
+		sys_put_le32(raw, dst);
+		break;
+	default:
+		return -EIO;
 	}
 
 	return 0;
 }
 
+#ifdef CONFIG_BT_MESH_SENSOR_USE_SENSOR_VALUE
 static int scalar_encode(const struct bt_mesh_sensor_format *format,
 			 const struct sensor_value *val,
 			 struct net_buf_simple *buf)
@@ -315,24 +352,7 @@ static int scalar_encode(const struct bt_mesh_sensor_format *format,
 		}
 	}
 
-	switch (format->size) {
-	case 1:
-		net_buf_simple_add_u8(buf, raw);
-		break;
-	case 2:
-		net_buf_simple_add_le16(buf, raw);
-		break;
-	case 3:
-		net_buf_simple_add_le24(buf, raw);
-		break;
-	case 4:
-		net_buf_simple_add_le32(buf, raw);
-		break;
-	default:
-		return -EIO;
-	}
-
-	return 0;
+	return scalar_encode_raw(format, raw, net_buf_simple_add(buf, format->size));
 }
 
 static int scalar_decode(const struct bt_mesh_sensor_format *format,
@@ -521,13 +541,111 @@ static bool percentage_delta_check(const struct bt_mesh_sensor_value *delta,
 	return (diff / prev) > (percentage_float);
 }
 
+static bool scalar_unknown_raw(const struct bt_mesh_sensor_format *format,
+			       int64_t *val)
+{
+	const struct scalar_repr *repr = format->user_data;
+
+	if (repr->flags & HAS_UNDEFINED) {
+		*val = scalar_type_max(format);
+	} else if (repr->flags & HAS_UNDEFINED_MIN) {
+		*val = scalar_type_min(format);
+	} else if (repr->flags & HAS_UNDEFINED_MAX_MINUS_1) {
+		*val = scalar_type_max(format) - 1;
+	} else {
+		return false;
+	}
+
+	return true;
+}
+
+static bool scalar_invalid_raw(const struct bt_mesh_sensor_format *format,
+			       int64_t *val)
+{
+	const struct scalar_repr *repr = format->user_data;
+
+	if (repr->flags & HAS_INVALID) {
+		*val = scalar_type_max(format) - 1;
+		if (repr->flags & HAS_UNDEFINED_MAX_MINUS_1) {
+			*val += 1;
+		}
+		return true;
+	}
+
+	return false;
+}
+
+static enum bt_mesh_sensor_value_status
+scalar_to_raw(const struct bt_mesh_sensor_value *sensor_val, int64_t *val)
+{
+	if (scalar_decode_raw(sensor_val->format, sensor_val->raw, val) != 0) {
+		return BT_MESH_SENSOR_VALUE_CONVERSION_ERROR;
+	}
+
+	const struct scalar_repr *repr = sensor_val->format->user_data;
+	int64_t max = scalar_max(sensor_val->format);
+	int32_t min = scalar_min(sensor_val->format);
+
+	if (*val == max && (repr->flags & HAS_HIGHER_THAN)) {
+		return BT_MESH_SENSOR_VALUE_MAX_OR_GREATER;
+	}
+
+	if (*val == min && (repr->flags & HAS_LOWER_THAN)) {
+		return BT_MESH_SENSOR_VALUE_MIN_OR_LESS;
+	}
+
+	if (IN_RANGE(*val, min, max)) {
+		return BT_MESH_SENSOR_VALUE_NUMBER;
+	}
+
+	int64_t special;
+
+	if (scalar_unknown_raw(sensor_val->format, &special) &&
+	    *val == special) {
+		return BT_MESH_SENSOR_VALUE_UNKNOWN;
+	}
+
+	if (scalar_invalid_raw(sensor_val->format, &special) &&
+	    *val == special) {
+		return BT_MESH_SENSOR_VALUE_INVALID;
+	}
+
+	return BT_MESH_SENSOR_VALUE_CONVERSION_ERROR;
+}
+
+static int scalar_from_raw(const struct bt_mesh_sensor_format *format,
+			   int64_t val,
+			   struct bt_mesh_sensor_value *sensor_val)
+{
+	int64_t max = scalar_max(format);
+	int32_t min = scalar_min(format);
+	int64_t clamped = CLAMP(val, min, max);
+
+	if (scalar_encode_raw(format, clamped, sensor_val->raw) != 0) {
+		return -EIO;
+	}
+
+	sensor_val->format = format;
+
+	return clamped != val ? -ERANGE : 0;
+}
+
 static int scalar_compare(const struct bt_mesh_sensor_value *op1,
 			  const struct bt_mesh_sensor_value *op2)
 {
+	enum bt_mesh_sensor_value_status status;
 	int64_t op1_raw, op2_raw;
 
-	(void)scalar_decode_raw(op1->format, op1->raw, &op1_raw);
-	(void)scalar_decode_raw(op2->format, op2->raw, &op2_raw);
+	status = scalar_to_raw(op1, &op1_raw);
+	if (!bt_mesh_sensor_value_status_is_numeric(status)) {
+		/* Not comparable, return -1. */
+		return -1;
+	}
+	status = scalar_to_raw(op2, &op2_raw);
+	if (!bt_mesh_sensor_value_status_is_numeric(status)) {
+		/* Not comparable, return -1. */
+		return -1;
+	}
 
 	if (op1_raw > op2_raw) {
 		return 1;
@@ -542,14 +660,18 @@ static bool scalar_delta_check(const struct bt_mesh_sensor_value *current,
 			       const struct bt_mesh_sensor_value *previous,
 			       const struct bt_mesh_sensor_deltas *deltas)
 {
-	const struct bt_mesh_sensor_value *delta;
 	int64_t current_raw, previous_raw, delta_raw;
+	const struct bt_mesh_sensor_value *delta;
+	enum bt_mesh_sensor_value_status curr_status, prev_status;
 
-	if (scalar_decode_raw(current->format, current->raw, &current_raw) != 0) {
-		return false;
-	}
-	if (scalar_decode_raw(previous->format, previous->raw, &previous_raw) != 0) {
-		return false;
+	curr_status = scalar_to_raw(current, &current_raw);
+	prev_status = scalar_to_raw(previous, &previous_raw);
+
+	if (!bt_mesh_sensor_value_status_is_numeric(curr_status) ||
+	    !bt_mesh_sensor_value_status_is_numeric(prev_status)) {
+		/* Always return true for changes involving non-numeric values.
+		 */
+		return curr_status != prev_status;
 	}
 
 	int64_t diff = current_raw - previous_raw;
@@ -565,12 +687,114 @@ static bool scalar_delta_check(const struct bt_mesh_sensor_value *current,
 		return percentage_delta_check(delta, diff, previous_raw);
 	}
 
-	if (scalar_decode_raw(delta->format, delta->raw, &delta_raw) != 0) {
+	enum bt_mesh_sensor_value_status status = scalar_to_raw(delta, &delta_raw);
+
+	if (!bt_mesh_sensor_value_status_is_numeric(status)) {
 		return false;
 	}
 
 	return diff > delta_raw;
 }
+
+static enum bt_mesh_sensor_value_status
+scalar_to_float(const struct bt_mesh_sensor_value *sensor_val, float *val)
+{
+	int64_t raw;
+	enum bt_mesh_sensor_value_status status = scalar_to_raw(sensor_val, &raw);
+
+	if (val && bt_mesh_sensor_value_status_is_numeric(status)) {
+		const struct scalar_repr *repr = sensor_val->format->user_data;
+
+		*val = MUL_SCALAR((float)raw, repr);
+	}
+
+	return status;
+}
+
+static int scalar_from_float(const struct bt_mesh_sensor_format *format,
+			     float val, struct bt_mesh_sensor_value *sensor_val)
+{
+	const struct scalar_repr *repr = sensor_val->format->user_data;
+	float raw = DIV_SCALAR(val, repr);
+
+	return scalar_from_raw(format, CLAMP(raw, INT64_MIN, INT64_MAX), sensor_val);
+}
+
+static enum bt_mesh_sensor_value_status
+scalar_to_sensor_value(const struct bt_mesh_sensor_value *sensor_val,
+		       struct sensor_value *val)
+{
+	int64_t raw;
+	enum bt_mesh_sensor_value_status status = scalar_to_raw(sensor_val, &raw);
+
+	if (val && bt_mesh_sensor_value_status_is_numeric(status)) {
+		const struct scalar_repr *repr = sensor_val->format->user_data;
+		int64_t million = MUL_SCALAR(raw * 1000000LL, repr);
+
+		val->val1 = million / 1000000LL;
+		val->val2 = million % 1000000LL;
+	}
+
+	return status;
+}
+
+static int scalar_from_sensor_value(const struct bt_mesh_sensor_format *format,
+				    const struct sensor_value *val,
+				    struct bt_mesh_sensor_value *sensor_val)
+{
+	const struct scalar_repr *repr = sensor_val->format->user_data;
+	int64_t raw = DIV_SCALAR(val->val1, repr) +
+		      DIV_SCALAR(val->val2, repr) / 1000000LL;
+
+	return scalar_from_raw(format, raw, sensor_val);
+}
+
+static int scalar_from_special(const struct bt_mesh_sensor_format *format,
+			       enum bt_mesh_sensor_value_status special,
+			       struct bt_mesh_sensor_value *sensor_val)
+{
+	const struct scalar_repr *repr = sensor_val->format->user_data;
+	int64_t raw;
+
+	switch (special) {
+	case BT_MESH_SENSOR_VALUE_UNKNOWN:
+		if(!scalar_unknown_raw(format, &raw)) {
+			return -ERANGE;
+		}
+		break;
+	case BT_MESH_SENSOR_VALUE_INVALID:
+		if(!scalar_invalid_raw(format, &raw)) {
+			return -ERANGE;
+		}
+		break;
+	case BT_MESH_SENSOR_VALUE_MAX_OR_GREATER:
+		if(!(repr->flags & HAS_HIGHER_THAN)) {
+			return -ERANGE;
+		}
+		raw = scalar_max(format);
+		break;
+	case BT_MESH_SENSOR_VALUE_MIN_OR_LESS:
+		if(!(repr->flags & HAS_LOWER_THAN)) {
+			return -ERANGE;
+		}
+		raw = scalar_min(format);
+		break;
+	default:
+		return -ERANGE;
+	}
+
+	return scalar_from_raw(format, raw, sensor_val);
+}
+
+static struct bt_mesh_sensor_format_cb scalar_cb = {
+	.compare = scalar_compare,
+	.delta_check = scalar_delta_check,
+	.to_float = scalar_to_float,
+	.from_float = scalar_from_float,
+	.to_sensor_value = scalar_to_sensor_value,
+	.from_sensor_value = scalar_from_sensor_value,
+	.from_special = scalar_from_special
+};
 
 static int boolean_compare(const struct bt_mesh_sensor_value *op1,
 			   const struct bt_mesh_sensor_value *op2)
@@ -608,6 +832,110 @@ static bool boolean_delta_check(const struct bt_mesh_sensor_value *current,
 	}
 
 	return diff > *(delta->raw);
+}
+
+static enum bt_mesh_sensor_value_status
+boolean_to_float(const struct bt_mesh_sensor_value *sensor_val, float *val)
+{
+	if (val) {
+		*val = !!*(sensor_val->raw);
+	}
+	return BT_MESH_SENSOR_VALUE_NUMBER;
+}
+
+static int boolean_from_float(const struct bt_mesh_sensor_format *format,
+			      float val, struct bt_mesh_sensor_value *sensor_val)
+{
+	sensor_val->format = format;
+	*(sensor_val->raw) = !!val;
+
+	if (val > 1.0f || val < 0.0f) {
+		return -ERANGE;
+	}
+
+	return 0;
+}
+
+static enum bt_mesh_sensor_value_status
+boolean_to_sensor_value(const struct bt_mesh_sensor_value *sensor_val,
+			struct sensor_value *val)
+{
+	if (val) {
+		val->val2 = 0;
+		val->val1 = !!*(sensor_val->raw);
+	}
+	return BT_MESH_SENSOR_VALUE_NUMBER;
+}
+
+static int boolean_from_sensor_value(const struct bt_mesh_sensor_format *format,
+				     const struct sensor_value *val,
+				     struct bt_mesh_sensor_value *sensor_val)
+{
+	sensor_val->format = format;
+	*(sensor_val->raw) = !!val->val1 || !!val->val2;
+
+	if ((val->val1 == 1 && val->val2 > 0) ||
+	    (val->val1 == 0 && val->val2 < 0) ||
+	    val->val1 > 1 || val->val1 < 0) {
+		return -ERANGE;
+	}
+
+	return 0;
+}
+
+static int boolean_from_special(const struct bt_mesh_sensor_format *format,
+				enum bt_mesh_sensor_value_status special,
+				struct bt_mesh_sensor_value *sensor_val)
+{
+	return -ERANGE;
+}
+
+static int boolean_to_string(const struct bt_mesh_sensor_value *sensor_val,
+			     char *str, size_t len)
+{
+	__ASSERT_NO_MSG(len >= 6);
+	if (*(sensor_val->raw) == 0) {
+		strcpy(str, "False");
+	} else {
+		strcpy(str, "True");
+	}
+
+	return 0;
+}
+
+static struct bt_mesh_sensor_format_cb boolean_cb = {
+	.compare = boolean_compare,
+	.delta_check = boolean_delta_check,
+	.to_float = boolean_to_float,
+	.from_float = boolean_from_float,
+	.to_sensor_value = boolean_to_sensor_value,
+	.from_sensor_value = boolean_from_sensor_value,
+	.from_special = boolean_from_special,
+	.to_string = boolean_to_string,
+};
+
+static enum bt_mesh_sensor_value_status
+to_sensor_value_via_float(const struct bt_mesh_sensor_value *sensor_val,
+			  struct sensor_value *val)
+{
+	enum bt_mesh_sensor_value_status status;
+	float float_val;
+
+	status = sensor_val->format->cb->to_float(sensor_val, &float_val);
+
+	if (val && bt_mesh_sensor_value_status_is_numeric(status) &&
+	    sensor_value_from_float(val, float_val) != 0) {
+		return BT_MESH_SENSOR_VALUE_CONVERSION_ERROR;
+	}
+
+	return status;
+}
+
+static int from_sensor_value_via_float(const struct bt_mesh_sensor_format *format,
+				       const struct sensor_value *val,
+				       struct bt_mesh_sensor_value *sensor_val)
+{
+	return format->cb->from_float(format, sensor_value_to_float(val), sensor_val);
 }
 
 /* This is the negative of the ceiling of the function d_1.1(-(i+1)), where d_1.1
@@ -710,17 +1038,112 @@ static bool exp_1_1_delta_check(const struct bt_mesh_sensor_value *current,
 	return exp_1_1_ceil_abs_diff(prev_raw, curr_raw) > *(delta->raw);
 }
 
-static float float32_to_float(const struct bt_mesh_sensor_value *sensor_val)
+static enum bt_mesh_sensor_value_status
+exp_1_1_to_float(const struct bt_mesh_sensor_value *sensor_val, float *val)
 {
-	uint32_t raw = sys_get_le32(sensor_val->raw);
+	uint8_t raw = *(sensor_val->raw);
 
-	return *(float *)(&raw);
+	if (raw == 0xff) {
+		return BT_MESH_SENSOR_VALUE_UNKNOWN;
+	}
+
+	if (raw == 0xfe) {
+		return BT_MESH_SENSOR_VALUE_TOTAL_DEVICE_LIFE;
+	}
+
+	if (val) {
+		*val = exp_1_1_decode_float(raw);
+	}
+	return BT_MESH_SENSOR_VALUE_NUMBER;
+}
+
+static int exp_1_1_from_float(const struct bt_mesh_sensor_format *format,
+			      float val, struct bt_mesh_sensor_value *sensor_val)
+{
+	sensor_val->format = format;
+	if (val == 0.0f) {
+		*(sensor_val->raw) = 0x00;
+		return 0;
+	}
+
+	float result = roundf(logf(val)/LOG_1_1);
+
+	*(sensor_val->raw) = CLAMP(result, 0x01, 0xfd);
+
+	if (result < 1 || result > 253) {
+		return -ERANGE;
+	}
+
+	return 0;
+}
+
+static int exp_1_1_from_special(const struct bt_mesh_sensor_format *format,
+				enum bt_mesh_sensor_value_status special,
+				struct bt_mesh_sensor_value *sensor_val)
+{
+	switch(special)
+	{
+	case BT_MESH_SENSOR_VALUE_UNKNOWN:
+		*(sensor_val->raw) = 0xff;
+		break;
+	case BT_MESH_SENSOR_VALUE_TOTAL_DEVICE_LIFE:
+		*(sensor_val->raw) = 0xfe;
+		break;
+	default:
+		return -ERANGE;
+	}
+
+	return 0;
+}
+
+static struct bt_mesh_sensor_format_cb exp_1_1_cb = {
+	.compare = exp_1_1_compare,
+	.delta_check = exp_1_1_delta_check,
+	.to_float = exp_1_1_to_float,
+	.from_float = exp_1_1_from_float,
+	.to_sensor_value = to_sensor_value_via_float,
+	.from_sensor_value = from_sensor_value_via_float,
+	.from_special = exp_1_1_from_special,
+};
+
+static enum bt_mesh_sensor_value_status
+float32_to_float(const struct bt_mesh_sensor_value *sensor_val, float *val)
+{
+	if (val) {
+		uint32_t raw = sys_get_le32(sensor_val->raw);
+
+		*val = *(float *)(&raw);
+	}
+	return BT_MESH_SENSOR_VALUE_NUMBER;
+}
+
+static int float32_from_float(const struct bt_mesh_sensor_format *format,
+			      float val, struct bt_mesh_sensor_value *sensor_val)
+{
+	uint32_t raw = *(uint32_t *)(&val);
+
+	sensor_val->format = format;
+	sys_put_le32(raw, sensor_val->raw);
+
+	return 0;
+}
+
+static int float32_from_special(const struct bt_mesh_sensor_format *format,
+				enum bt_mesh_sensor_value_status special,
+				struct bt_mesh_sensor_value *sensor_val)
+{
+	return -ERANGE;
 }
 
 static int float32_compare(const struct bt_mesh_sensor_value *op1,
 			  const struct bt_mesh_sensor_value *op2)
 {
-	float diff = float32_to_float(op1) - float32_to_float(op2);
+	float op1_float, op2_float;
+
+	(void)float32_to_float(op1, &op1_float);
+	(void)float32_to_float(op2, &op2_float);
+
+	float diff = op1_float - op2_float;
 
 	if (diff > 0.0f) {
 		return 1;
@@ -737,8 +1160,12 @@ static bool float32_delta_check(const struct bt_mesh_sensor_value *current,
 {
 	const struct bt_mesh_sensor_value *delta;
 
-	float prev_float = float32_to_float(previous);
-	float diff = float32_to_float(current) - prev_float;
+	float prev_float, curr_float;
+
+	(void)float32_to_float(previous, &prev_float);
+	(void)float32_to_float(current, &curr_float);
+
+	float diff = curr_float - prev_float;
 
 	if (diff < 0.0f) {
 		diff = -diff;
@@ -751,10 +1178,22 @@ static bool float32_delta_check(const struct bt_mesh_sensor_value *current,
 		return percentage_delta_check(delta, diff, prev_float);
 	}
 
-	float delta_float = float32_to_float(delta);
+	float delta_float;
+
+	(void)float32_to_float(delta, &delta_float);
 
 	return diff > delta_float;
 }
+
+static struct bt_mesh_sensor_format_cb float32_cb = {
+	.compare = float32_compare,
+	.delta_check = float32_delta_check,
+	.to_float = float32_to_float,
+	.from_float = float32_from_float,
+	.to_sensor_value = to_sensor_value_via_float,
+	.from_sensor_value = from_sensor_value_via_float,
+	.from_special = float32_from_special,
+};
 #endif /* defined(CONFIG_BT_MESH_SENSOR_USE_SENSOR_VALUE) */
 
 /*******************************************************************************
@@ -781,7 +1220,7 @@ FORMAT(percentage_16) = SCALAR_FORMAT_MAX(2,
 					  SCALAR(1e-2, 0),
 					  10000);
 FORMAT(percentage_delta_trigger) = SCALAR_FORMAT(2,
-					  (UNSIGNED | HAS_UNDEFINED),
+					  UNSIGNED,
 					  percent,
 					  SCALAR(1e-2, 0));
 
@@ -878,8 +1317,7 @@ FORMAT(time_exp_8)	    = {
 	.encode = exp_1_1_encode,
 	.decode = exp_1_1_decode,
 #else
-	.compare = exp_1_1_compare,
-	.delta_check = exp_1_1_delta_check,
+	.cb = &exp_1_1_cb,
 #endif
 };
 
@@ -894,7 +1332,8 @@ FORMAT(electric_current) = SCALAR_FORMAT_MAX(2,
 FORMAT(voltage)		 = SCALAR_FORMAT_MAX(2,
 					 (UNSIGNED |
 					 HAS_UNDEFINED |
-					 HAS_HIGHER_THAN),
+					 HAS_HIGHER_THAN |
+					 HAS_LOWER_THAN),
 					 volt,
 					 SCALAR(1, -6),
 					 65408);
@@ -925,7 +1364,7 @@ FORMAT(energy)           = SCALAR_FORMAT(3,
 FORMAT(chromatic_distance)      = SCALAR_FORMAT_MIN_MAX(2,
 							(SIGNED |
 							HAS_INVALID |
-							HAS_UNDEFINED),
+							HAS_UNDEFINED_MAX_MINUS_1),
 							unitless, SCALAR(1e-5, 0),
 							-5000, 5000);
 FORMAT(chromaticity_coordinate) = SCALAR_FORMAT(2,
@@ -989,8 +1428,7 @@ FORMAT(boolean) = {
 	.encode = boolean_encode,
 	.decode = boolean_decode,
 #else
-	.compare = boolean_compare,
-	.delta_check = boolean_delta_check,
+	.cb = &boolean_cb,
 #endif
 	.size	= 1,
 #ifdef CONFIG_BT_MESH_SENSOR_LABELS
@@ -1002,8 +1440,7 @@ FORMAT(coefficient) = {
 	.encode = float32_encode,
 	.decode = float32_decode,
 #else
-	.compare = float32_compare,
-	.delta_check = float32_delta_check,
+	.cb = &float32_cb,
 #endif
 	.size	= 4,
 #ifdef CONFIG_BT_MESH_SENSOR_LABELS


### PR DESCRIPTION
This adds utility functions for converting struct bt_mesh_sensor_value values to and from float and sensor value, and to string.